### PR TITLE
fix: check deleted file pragmas

### DIFF
--- a/bin/if-changed.rs
+++ b/bin/if-changed.rs
@@ -247,7 +247,7 @@ mod tests {
     }
 
     #[test]
-    fn test_run_staged_deletion() {
+    fn test_run_staged_deletion_fail() {
         let (tempdir, repo) = git_test! {
             "initial commit": [
                 "a.ts" => indoc! {"
@@ -256,12 +256,44 @@ mod tests {
                         A,
                         // then-change(b.ts)
                     }
-                "}
+                "},
+                "b.ts" => ""
             ]
         };
         std::fs::remove_file(tempdir.path().join("a.ts")).unwrap();
         let mut index = repo.index().unwrap();
         index.remove_path(std::path::Path::new("a.ts")).unwrap();
+        index.write().unwrap();
+
+        let repository = git2::Repository::open(tempdir.path()).unwrap();
+        insta::assert_compact_json_snapshot!(run(Cli {
+            from_ref: None,
+            to_ref: None,
+            patterns: vec!["*".into()],
+        }, repository).collect::<Vec<_>>(), @r###"["Expected \"b.ts\" to be modified because of \"then-change\" in \"a.ts\" at line 4."]"###);
+    }
+
+    #[test]
+    fn test_run_staged_deletion_with_deleted_dependency() {
+        let (tempdir, repo) = git_test! {
+            "initial commit": [
+                "a.ts" => indoc! {"
+                    const enum G {
+                        // if-changed
+                        A,
+                        // then-change(b.ts)
+                    }
+                "},
+                "b.ts" => ""
+            ]
+        };
+        for path in ["a.ts", "b.ts"] {
+            std::fs::remove_file(tempdir.path().join(path)).unwrap();
+        }
+        let mut index = repo.index().unwrap();
+        for path in ["a.ts", "b.ts"] {
+            index.remove_path(std::path::Path::new(path)).unwrap();
+        }
         index.write().unwrap();
 
         let repository = git2::Repository::open(tempdir.path()).unwrap();

--- a/engine.rs
+++ b/engine.rs
@@ -2,6 +2,7 @@ mod git;
 
 use std::{
     collections::BTreeMap,
+    fs, io,
     path::{Path, PathBuf},
 };
 
@@ -21,6 +22,11 @@ pub trait Engine {
     /// Resolve a path to an absolute path.
     fn resolve(&self, path: impl AsRef<Path>) -> PathBuf;
 
+    /// Read the file content that should be checked.
+    fn read_to_string(&self, path: impl AsRef<Path>) -> Result<String, io::Error> {
+        fs::read_to_string(self.resolve(path))
+    }
+
     /// Check if a file has been ignored.
     fn is_ignored(&self, path: impl AsRef<Path>) -> bool;
 
@@ -30,8 +36,8 @@ pub trait Engine {
     /// Check a file for dependent changes.
     fn check(&self, path: impl AsRef<Path>) -> Result<(), Vec<String>> {
         let path = path.as_ref();
-        let parser = match Parser::new(path, self.resolve(path)) {
-            Ok(parser) => parser,
+        let parser = match self.read_to_string(path) {
+            Ok(source) => Parser::from_source(path, source),
             Err(error) => return Err(vec![format!("Could not open {path:?}: {error}")]),
         };
 
@@ -94,8 +100,8 @@ pub trait Engine {
                     };
 
                     // Try to open the file in search of the named block.
-                    let mut parser = match Parser::new(&dependent, self.resolve(&dependent)) {
-                        Ok(parser) => parser,
+                    let mut parser = match self.read_to_string(&dependent) {
+                        Ok(source) => Parser::from_source(&dependent, source),
                         Err(error) => {
                             errors.push(format!(
                                 "Could not open {dependent:?} for \"then-change\" in {path:?} at line {line}: {error:?}"
@@ -242,6 +248,56 @@ mod tests {
             .first()
             .unwrap()
             .contains("Could not open \"a.js\""));
+    }
+
+    #[test]
+    fn test_check_deleted_file_fail() {
+        let (tempdir, repo) = git_test! {
+            "initial commit": [
+                "src/a.js" => indoc!{"
+                    // if-changed
+                    foo
+                    // then-change(b.js)
+                "},
+                "src/b.js" => ""
+            ]
+        };
+        std::fs::remove_file(tempdir.path().join("src/a.js")).unwrap();
+        let mut index = repo.index().unwrap();
+        index.remove_path(Path::new("src/a.js")).unwrap();
+        index.write().unwrap();
+
+        let engine = GitEngine::new(&repo, None, None);
+        assert_eq!(engine.resolve(""), tempdir.path().canonicalize().unwrap());
+
+        insta::assert_compact_json_snapshot!(engine.check(Path::new("src/a.js")), @r###"{"Err": ["Expected \"src/b.js\" to be modified because of \"then-change\" in \"src/a.js\" at line 3."]}"###);
+    }
+
+    #[test]
+    fn test_check_deleted_file_with_deleted_dependency() {
+        let (tempdir, repo) = git_test! {
+            "initial commit": [
+                "src/a.js" => indoc!{"
+                    // if-changed
+                    foo
+                    // then-change(b.js)
+                "},
+                "src/b.js" => ""
+            ]
+        };
+        for path in ["src/a.js", "src/b.js"] {
+            std::fs::remove_file(tempdir.path().join(path)).unwrap();
+        }
+        let mut index = repo.index().unwrap();
+        for path in ["src/a.js", "src/b.js"] {
+            index.remove_path(Path::new(path)).unwrap();
+        }
+        index.write().unwrap();
+
+        let engine = GitEngine::new(&repo, None, None);
+        assert_eq!(engine.resolve(""), tempdir.path().canonicalize().unwrap());
+
+        insta::assert_compact_json_snapshot!(engine.check(Path::new("src/a.js")), @r###"{"Ok": null}"###);
     }
 
     #[test]

--- a/engine/git.rs
+++ b/engine/git.rs
@@ -1,5 +1,6 @@
 use std::{
     borrow::{BorrowMut, Cow},
+    fs, io,
     path::{Path, PathBuf, MAIN_SEPARATOR_STR},
     str::FromStr as _,
 };
@@ -11,11 +12,12 @@ use super::Engine;
 
 const IF_CHANGED_IGNORE_TRAILER: &[u8] = b"ignore-if-changed";
 
-fn checked_path(delta: git2::DiffDelta<'_>) -> Option<PathBuf> {
-    if delta.status() == git2::Delta::Deleted {
-        return None;
+fn changed_path(delta: git2::DiffDelta<'_>) -> Option<PathBuf> {
+    match delta.status() {
+        git2::Delta::Deleted => delta.old_file().path(),
+        _ => delta.new_file().path(),
     }
-    delta.new_file().path().map(Path::to_owned)
+    .map(Path::to_owned)
 }
 
 pub struct GitEngine<'repo> {
@@ -111,6 +113,38 @@ impl<'repo> GitEngine<'repo> {
         .ok()
         .flatten()
     }
+
+    fn is_deleted(&self, path: &Path) -> bool {
+        self.patch(path)
+            .is_some_and(|patch| patch.delta().status() == git2::Delta::Deleted)
+    }
+
+    fn read_old_blob(&self, path: &Path) -> Result<String, io::Error> {
+        let tree = self.from_tree.as_ref().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("no base tree contains {}", path.display()),
+            )
+        })?;
+        let entry = tree.get_path(path).map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("could not find {} in base tree: {error}", path.display()),
+            )
+        })?;
+        let blob = entry
+            .to_object(self.repository)
+            .and_then(|object| object.peel_to_blob())
+            .map_err(|error| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("could not read {} from base tree: {error}", path.display()),
+                )
+            })?;
+        std::str::from_utf8(blob.content())
+            .map(str::to_owned)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+    }
 }
 
 impl Engine for GitEngine<'_> {
@@ -136,7 +170,7 @@ impl Engine for GitEngine<'_> {
         gen!({
             if patterns.is_empty() {
                 for delta in diff.deltas() {
-                    if let Some(path) = checked_path(delta) {
+                    if let Some(path) = changed_path(delta) {
                         yield_!(Ok(path))
                     }
                 }
@@ -148,7 +182,7 @@ impl Engine for GitEngine<'_> {
                 .match_diff(&diff, git2::PathspecFlags::FIND_FAILURES)
                 .expect("bare repos are not supported");
             for delta in matches.diff_entries() {
-                if let Some(path) = checked_path(delta) {
+                if let Some(path) = changed_path(delta) {
                     yield_!(Ok(path))
                 }
             }
@@ -168,6 +202,15 @@ impl Engine for GitEngine<'_> {
             .join(path.as_ref())
     }
 
+    fn read_to_string(&self, path: impl AsRef<Path>) -> Result<String, io::Error> {
+        let path = path.as_ref();
+        if self.is_deleted(path) {
+            self.read_old_blob(path)
+        } else {
+            fs::read_to_string(self.resolve(path))
+        }
+    }
+
     fn is_ignored(&self, path: impl AsRef<Path>) -> bool {
         let Some(pathspec) = &self.ignore_pathspec else {
             return false;
@@ -183,13 +226,7 @@ impl Engine for GitEngine<'_> {
         if patch.delta().status() == git2::Delta::Untracked {
             return true;
         }
-        for (hunk_index, hunk) in (0..patch.num_hunks()).map(|i| (i, patch.hunk(i).unwrap().0)) {
-            if usize::try_from(hunk.new_start()).unwrap() > range.1 {
-                break;
-            }
-            if usize::try_from(hunk.new_start() + hunk.new_lines()).unwrap() < range.0 {
-                continue;
-            }
+        for hunk_index in 0..patch.num_hunks() {
             for line in (0..patch.num_lines_in_hunk(hunk_index).unwrap())
                 .map(|i| patch.line_in_hunk(hunk_index, i).unwrap())
             {
@@ -359,8 +396,8 @@ mod tests {
         let engine = GitEngine::new(&repo, None, None);
         assert_eq!(engine.resolve(""), tempdir.path().canonicalize().unwrap());
 
-        insta::assert_compact_json_snapshot!(engine.matches(["";0]).collect::<Vec<_>>(), @"[]");
-        insta::assert_compact_json_snapshot!(engine.matches(["*"]).collect::<Vec<_>>(), @"[]");
+        insta::assert_compact_json_snapshot!(engine.matches(["";0]).collect::<Vec<_>>(), @r###"[{"Ok": "a"}]"###);
+        insta::assert_compact_json_snapshot!(engine.matches(["*"]).collect::<Vec<_>>(), @r###"[{"Ok": "a"}]"###);
     }
 
     #[test]

--- a/parser.rs
+++ b/parser.rs
@@ -1,6 +1,4 @@
 use std::{
-    fs,
-    io::{self, BufRead},
     ops::{Deref, DerefMut},
     path::{Path, PathBuf},
     str::FromStr,
@@ -76,34 +74,32 @@ impl DerefMut for NumberedLine {
 pub(super) struct Parser {
     path: PathBuf,
 
-    lines: io::Lines<io::BufReader<std::fs::File>>,
+    lines: std::vec::IntoIter<String>,
     line: NumberedLine,
 
     blocks: Vec<IfChangedBlock>,
 }
 
 impl Parser {
-    pub(super) fn new(
-        relpath: impl AsRef<Path>,
-        path: impl AsRef<Path>,
-    ) -> Result<Parser, io::Error> {
-        Ok(Parser {
+    pub(super) fn from_source(relpath: impl AsRef<Path>, source: String) -> Parser {
+        Parser {
             path: relpath.as_ref().to_owned(),
-            lines: io::BufReader::new(fs::File::open(&path)?).lines(),
+            lines: source
+                .lines()
+                .map(ToOwned::to_owned)
+                .collect::<Vec<_>>()
+                .into_iter(),
             line: NumberedLine::new(0, String::default()),
             blocks: Vec::new(),
-        })
+        }
     }
 
     fn next_line(&mut self) -> Result<bool, Vec<String>> {
         match self.lines.next() {
-            Some(result) => match result {
-                Ok(line) => {
-                    self.line = NumberedLine::new(self.line.number + 1, line);
-                    Ok(true)
-                }
-                Err(value) => Err(vec![format!("Failed to read {}: {:?}", value, self.path)]),
-            },
+            Some(line) => {
+                self.line = NumberedLine::new(self.line.number + 1, line);
+                Ok(true)
+            }
             None => Ok(false),
         }
     }
@@ -334,21 +330,17 @@ impl Iterator for Parser {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Write;
-
-    use tempfile::NamedTempFile;
-
     use super::Parser;
 
     macro_rules! parser_test {
         ($name:ident, $value:expr, @$exp:literal) => {
             #[test]
             fn $name() {
-                let mut file = NamedTempFile::new().unwrap();
-                writeln!(file, $value).unwrap();
-                insta::assert_compact_json_snapshot!(Parser::new(file.path(), file.path())
-                    .unwrap()
-                    .collect::<Result<Vec<_>, _>>(), @$exp);
+                insta::assert_compact_json_snapshot!(Parser::from_source(
+                    stringify!($name),
+                    format!("{}\n", $value),
+                )
+                .collect::<Result<Vec<_>, _>>(), @$exp);
             }
         };
     }


### PR DESCRIPTION
## Summary

- Parse deleted files from the base tree instead of skipping them.
- Count deleted paths as changed dependents while still validating named blocks from their old contents.
- Evaluate deleted hunk lines by old line number so deletion-only hunks can trigger affected `if-changed` ranges.
- Keep parser input source-based so current worktree files and old git blobs share the same parsing path.

## Root Cause

The previous fix avoided missing-file crashes by skipping deleted diff deltas. That fixed hooks with renames/deletions, but it also skipped enforcement for deleted files that contained `if-changed` blocks. The checker also filtered hunks by new-file ranges before inspecting deleted old lines, so deletion-only changes could be missed.

## Validation

- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
